### PR TITLE
TEL-2490 Fixes test suite and paths by adding .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PYTHONPATH=src

--- a/src/handler.py
+++ b/src/handler.py
@@ -5,11 +5,10 @@ from aws_lambda_context import LambdaContext
 from aws_lambda_powertools import Logger
 from botocore.config import Config
 from botocore.exceptions import ClientError
+from exceptions import EmptyEventDetailException
+from exceptions import NoExecutionIdFoundException
 from github import Github
-
-from .exceptions import EmptyEventDetailException
-from .exceptions import NoExecutionIdFoundException
-from .helper import Helper
+from helper import Helper
 
 
 config = Config(retries={"max_attempts": 60, "mode": "standard"})

--- a/tests/unit/handler_test.py
+++ b/tests/unit/handler_test.py
@@ -124,8 +124,8 @@ def test_lambda_handler_invalid_event_empty_detail_with_context(
 ):
     """Test that an event containing unexpected data with lambda context logs appropriately"""
     # Arrange & Act
-    from src.exceptions import EmptyEventDetailException
-    from src.handler import enrich_codepipeline_event
+    from exceptions import EmptyEventDetailException
+    from handler import enrich_codepipeline_event
 
     with pytest.raises(EmptyEventDetailException):
         response = enrich_codepipeline_event(
@@ -141,8 +141,8 @@ def test_lambda_handler_invalid_event_with_no_execution_id(
 ):
     """Test that an event containing missing and required data with lambda context logs appropriately"""
     # Arrange & Act
-    from src.exceptions import NoExecutionIdFoundException
-    from src.handler import enrich_codepipeline_event
+    from exceptions import NoExecutionIdFoundException
+    from handler import enrich_codepipeline_event
 
     with pytest.raises(NoExecutionIdFoundException):
         response = enrich_codepipeline_event(


### PR DESCRIPTION
What did we do?
--

1. The tests were passing but the Lambda failed, claiming it couldn't resolve dependencies.
2. If we flipped it around, the lambda works and tests fail

Eliminating `.` and `src` from the imports is the way we've done other Lambdas

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-2490

Evidence of work
--

1. Test suite passing
2. Toy lambda with this setup works for me

![image](https://user-images.githubusercontent.com/205245/211869843-d8426516-39cd-48fc-ac56-dc480ecdb3ce.png)

Next Steps
--

1. Test Lambda

Risks
--

1. Not working on Lee's machine
2. We should probably remove the `.env` file, it's a hack
    a. It also exists on `aws-lambda-ec2-launch-checks`

Collaboration
--

Co-authored-by: Lee Myring <29373851+thinkstack@users.noreply.github.com>
