### PR TITLE
TEL-2490 Adds support for SQS messages

### DIFF
--- a/src/helper.py
+++ b/src/helper.py
@@ -1,3 +1,6 @@
+import json
+
+
 class Helper:
     github_to_slack = {
         "1422984+webit4me@users.noreply.github.com": "ali.bahman",
@@ -26,3 +29,10 @@ class Helper:
             f"Returned Slack handle {slack_handle} for GitHub email {github_email}"
         )
         return slack_handle
+
+    def open_sqs_envelope(self, sqs_message: list) -> dict:
+        """
+        SQS messages are like an "envelope" wrapping the message we want.
+        This method "opens" the "envelope" and returns the message body.
+        """
+        return json.loads(sqs_message[0].get("body"))

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -148,3 +148,42 @@ def cloudwatch_event_invalid_no_execution_id():
             "state": "FAILED",
         },
     }
+
+
+@pytest.fixture(scope="function")
+def sqs_message_containing_cloudwatch_event_pipeline_failed() -> list:
+    return [
+        {
+            "messageId": "9d6cd254-4dfa-4646-955f-1a58a10ad819",
+            "receiptHandle": "SQS_RECEIPT_HANDLE",
+            "body": "{"
+            '"version":"0",'
+            '"id":"4da4f3e3-5b27-557c-b293-a8a8b4a54213",'
+            '"detail-type":"CodePipeline Pipeline Execution State Change",'
+            '"source":"aws.codepipeline",'
+            '"account":"047384126872",'
+            '"time":"2023-01-12T09:44:42Z",'
+            '"region":"eu-west-2",'
+            '"resources":["arn:aws:codepipeline:eu-west-2:047384126872:TEL-2490"],'
+            '"detail":'
+            "{"
+            '"pipeline":"TEL-2490",'
+            '"execution-id":"b75f5f61-5186-4e09-9252-33e1b3adcb41",'
+            '"execution-trigger":{"trigger-type":"ChangeAutomation","trigger-detail":"Source"},'
+            '"state":"STARTED",'
+            '"version":1.0'
+            "}"
+            "}",
+            "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "1673516693333",
+                "SenderId": "AIDAIMVB327QFXLX37UZW",
+                "ApproximateFirstReceiveTimestamp": "1673516693335",
+            },
+            "messageAttributes": {},
+            "md5OfBody": "981af7ffb45db0966f7419c9d42be550",
+            "eventSource": "aws:sqs",
+            "eventSourceARN": "arn:aws:sqs:eu-west-2:047384126872:codebuild-failures",
+            "awsRegion": "eu-west-2",
+        }
+    ]

--- a/tests/unit/helper_test.py
+++ b/tests/unit/helper_test.py
@@ -31,3 +31,13 @@ def test_get_slack_handle_for_valid_users(valid_users, helper):
 def test_get_slack_handle_for_invalid_user_throws(helper):
     """Test that users that are not in the helper causes an exception to be raised"""
     helper.get_slack_handle("i-do-not-exist")
+
+
+def test_open_sqs_envelope(
+    helper, sqs_message_containing_cloudwatch_event_pipeline_failed
+):
+    """Test that the SQS envelope can be opened"""
+    event = helper.open_sqs_envelope(
+        sqs_message_containing_cloudwatch_event_pipeline_failed
+    )
+    assert event.get("id") == "4da4f3e3-5b27-557c-b293-a8a8b4a54213"


### PR DESCRIPTION
What we have done
--

The Lambda is receiving messages from SQS, which are wrapped in an SQS "envelope"

References
--

1. https://jira.tools.tax.service.gov.uk/browse/TEL-2490

Evidence of work
--

1. Automated tests

Risks
--

1. We did not remove `enrich_codepipeline_event` as a public API function

Next steps
--

1. Modify Lambda to use `handler.enrich_sqs_event` as handler

Collaborators
--

1. Co-Author: Lee Myring Think Stack Limited <29373851+thinkstack@users.noreply.github.com>
