### PR TITLE
TEL-2490 - add enriched_title to event object

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -127,4 +127,8 @@ def enrich_codepipeline_event(event: dict, context: LambdaContext) -> str:
     slack_handle = helper.get_slack_handle(author_email)
     event.get("detail")["slack_handle"] = slack_handle
 
+    event.get("detail")[
+        "enriched_title"
+    ] = f"CodePipeline failed: {pipeline}. Committer: @{slack_handle} Sha: {commit_sha}"
+
     return event

--- a/tests/unit/handler_test.py
+++ b/tests/unit/handler_test.py
@@ -149,9 +149,11 @@ def test_get_pipeline_execution_handles_incorrect_pipeline(codepipeline_client_s
     )
 
 
+# @patch("handler.get_pipeline_commit_sha")
 @patch("handler.get_github_author_email")
 def test_handler_golden_path(
-    mock_github,
+    mock_github_author,
+    # mock_github_sha,
     ssm,
     codepipeline_client_stub,
     get_pipeline_execution_success_fixture,
@@ -161,7 +163,8 @@ def test_handler_golden_path(
     # Arrange
     from handler import enrich_codepipeline_event
 
-    mock_github.return_value = "29373851+thinkstack@users.noreply.github.com"
+    mock_github_author.return_value = "29373851+thinkstack@users.noreply.github.com"
+    # mock_github_sha.return_value = "3353a6dc5470a04d1cee8712db7d63fd7ee0be88"
     ssm.put_parameter(Name="telemetry_github_token", Value="token123")
     codepipeline_client_stub.add_response(
         "get_pipeline_execution", get_pipeline_execution_success_fixture
@@ -173,6 +176,10 @@ def test_handler_golden_path(
     # Assert
     assert response is not None
     assert response.get("detail").get("slack_handle") == "lee.myring"
+    assert (
+        response.get("detail").get("enriched_title")
+        == "CodePipeline failed: myPipeline. Committer: @lee.myring Sha: bc051f8d7fbf183dbb840462cb5c17d887964842"
+    )
 
 
 def test_lambda_handler_invalid_event_empty_detail_with_context(

--- a/tests/unit/handler_test.py
+++ b/tests/unit/handler_test.py
@@ -149,11 +149,9 @@ def test_get_pipeline_execution_handles_incorrect_pipeline(codepipeline_client_s
     )
 
 
-# @patch("handler.get_pipeline_commit_sha")
 @patch("handler.get_github_author_email")
 def test_handler_golden_path(
     mock_github_author,
-    # mock_github_sha,
     ssm,
     codepipeline_client_stub,
     get_pipeline_execution_success_fixture,
@@ -164,7 +162,6 @@ def test_handler_golden_path(
     from handler import enrich_codepipeline_event
 
     mock_github_author.return_value = "29373851+thinkstack@users.noreply.github.com"
-    # mock_github_sha.return_value = "3353a6dc5470a04d1cee8712db7d63fd7ee0be88"
     ssm.put_parameter(Name="telemetry_github_token", Value="token123")
     codepipeline_client_stub.add_response(
         "get_pipeline_execution", get_pipeline_execution_success_fixture


### PR DESCRIPTION
What did we do?
--

1. Adds a new output string to the event - `enriched_title` - containing several event details in one contiguous string

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-2490

Evidence of work
--

1.

Next Steps
--

1.

Risks
--

1.

Collaboration
--

Co-authored-by:
