### PR TITLE
TEL-2490 Removes unnecessary API call

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -967,19 +967,6 @@ url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple"
 reference = "artifactory"
 
 [[package]]
-name = "pytz"
-version = "2022.7"
-description = "World timezone definitions, modern and historical"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.source]
-type = "legacy"
-url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple"
-reference = "artifactory"
-
-[[package]]
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
@@ -1325,7 +1312,7 @@ reference = "artifactory"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "647c2781b60c27779f0f068073cbb48edb63f771dc3641f28e632a7f82dcd00e"
+content-hash = "c21add330e1bdd49258cb5ec7bf877fffd62b38cee88b877602677b0ebaf0069"
 
 [metadata.files]
 arrow = [
@@ -1735,10 +1722,6 @@ python-dateutil = [
 python-slugify = [
     {file = "python-slugify-7.0.0.tar.gz", hash = "sha256:7a0f21a39fa6c1c4bf2e5984c9b9ae944483fd10b54804cb0e23a3ccd4954f0b"},
     {file = "python_slugify-7.0.0-py2.py3-none-any.whl", hash = "sha256:003aee64f9fd955d111549f96c4b58a3f40b9319383c70fad6277a4974bbf570"},
-]
-pytz = [
-    {file = "pytz-2022.7-py2.py3-none-any.whl", hash = "sha256:93007def75ae22f7cd991c84e02d434876818661f8df9ad5df9e950ff4e52cfd"},
-    {file = "pytz-2022.7.tar.gz", hash = "sha256:7ccfae7b4b2c067464a6733c6261673fdb8fd1be905460396b97a073e9fa683a"},
 ]
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ pre-commit = "^2.21.0"
 pytest = "^7.2.0"
 pytest-cov = "^4.0.0"
 version-incrementor = "^1.5.0"
-pytz = "^2022.7"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/handler.py
+++ b/src/handler.py
@@ -37,12 +37,12 @@ def get_ssm_parameter(ssm_parameter: str) -> str:
 def get_pipeline_commit_data(name: str, execution_id: str) -> dict:
     """
     Returns map like:
-                {
-                "name": "source_output",
-                "revisionId": "afd432bc775c1a24c17b421187950a3af15db703",
-                "revisionSummary": "lambda-eventbridge-enrichment0.0.12->0.0.15 (#2250)",
-                "revisionUrl": "https://github.com/hmrc/telemetry-terraform/commit/afd432bc775c1a24c17b421187950a3af15db703"
-            }
+    {
+        "name": "source_output",
+        "revisionId": "afd432bc775c1a24c17b421187950a3af15db703",
+        "revisionSummary": "lambda-eventbridge-enrichment0.0.12->0.0.15 (#2250)",
+        "revisionUrl": "https://github.com/hmrc/telemetry-terraform/commit/afd432bc775c1a24c17b421187950a3af15db703"
+    }
     """
     try:
         response = pipeline_client.get_pipeline_execution(

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 
 import boto3
 import pytest
-import pytz
 from aws_lambda_context import LambdaContext
 from botocore.stub import Stubber
 from moto import mock_ssm

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -70,7 +70,6 @@ def get_pipeline_execution_success_fixture():
             "artifactRevisions": [
                 {
                     "name": "source_output",
-                    "created": datetime.now(pytz.utc) - timedelta(minutes=61),
                     "revisionId": "bc051f8d7fbf183dbb840462cb5c17d887964842",
                     "revisionSummary": "TEL-3481 create pagerduty-config-deployer",
                     "revisionUrl": "https://github.com/hmrc/telemetry-terraform/commit/bc051f8d7fbf183dbb840462cb5c17d887964842",


### PR DESCRIPTION
What did we do?
--

1. We discovered that the AWS API for CodePipeline actually contained the revision summary, so no need to go get it expressly
2. Removed dependency on `pytz`

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-2490

Evidence of work
--

1. Unit tests
3. Observed API behaviour
![image](https://user-images.githubusercontent.com/205245/212375828-bb4508e2-1803-4252-9fdb-df18bc696161.png)

Next Steps
--

1. We COULD modify the PagerDuty lambda to add this URL
2. Deploy new vn of this lambda

Risks
--

Nothing known

Collaboration
--

Co-authored-by: Willem Veerman <6502426+willemveerman@users.noreply.github.com>
