### PR TITLE
TEL-2490 Uses first line of commit summary only

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -134,8 +134,8 @@ def enrich_codepipeline_event(event: dict, context: LambdaContext) -> str:
     slack_handle = helper.get_slack_handle(author_email)
     event.get("detail")["slack_handle"] = slack_handle
     commit_sha = commit_data.get("revisionId")
-    commit_message_summary = commit_data.get("revisionSummary")
-    event.get("detail")["commit_message_summary"] = commit_data.get("revisionSummary")
+    commit_message_summary = commit_data.get("revisionSummary").partition("\n")[0]
+    event.get("detail")["commit_message_summary"] = commit_message_summary
     event.get("detail")["commit_url"] = commit_data.get("revisionUrl")
     event.get("detail")[
         "enriched_title"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -70,7 +70,7 @@ def get_pipeline_execution_success_fixture():
                 {
                     "name": "source_output",
                     "revisionId": "bc051f8d7fbf183dbb840462cb5c17d887964842",
-                    "revisionSummary": "TEL-3481 create pagerduty-config-deployer",
+                    "revisionSummary": "TEL-3481 create pagerduty-config-deployer\n\nBunch of text",
                     "revisionUrl": "https://github.com/hmrc/telemetry-terraform/commit/bc051f8d7fbf183dbb840462cb5c17d887964842",
                 }
             ],

--- a/tests/unit/handler_test.py
+++ b/tests/unit/handler_test.py
@@ -49,7 +49,7 @@ def test_get_pipeline_commit_data_returns_commit_from_source_output(
     assert git_data == {
         "name": "source_output",
         "revisionId": "bc051f8d7fbf183dbb840462cb5c17d887964842",
-        "revisionSummary": "TEL-3481 create pagerduty-config-deployer",
+        "revisionSummary": "TEL-3481 create pagerduty-config-deployer\n\nBunch of text",
         "revisionUrl": "https://github.com/hmrc/telemetry-terraform/commit/bc051f8d7fbf183dbb840462cb5c17d887964842",
     }
 


### PR DESCRIPTION
What we have done
--

The commit summary was including the whole commit message, problem looked like:

![image](https://user-images.githubusercontent.com/205245/212649988-30783e79-097d-476b-9644-333096335d33.png)

so we just take the header line now.

We had thought that AWS did this automatically in the build result, they do not.

...

References
--

1. https://jira.tools.tax.service.gov.uk/browse/TEL-2490

Evidence of work
--

1. Automated tests updated

Risks
--

1. Nothing specific known

Next steps
--

1. Deploy via Terraform

Collaborators
--

1. Co-authored-by: Stephen Palfreyman <18111914+sjpalf@users.noreply.github.com>
