### PR TITLE
TEL-3506 update output for slack notifications lambda rather than pagerduty

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -431,6 +431,22 @@ url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple"
 reference = "artifactory"
 
 [[package]]
+name = "classify-imports"
+version = "4.2.0"
+description = "Utilities for refactoring imports in python-like syntax."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "classify_imports-4.2.0-py2.py3-none-any.whl", hash = "sha256:dbbc264b70a470ed8c6c95976a11dfb8b7f63df44ed1af87328bbed2663f5161"},
+    {file = "classify_imports-4.2.0.tar.gz", hash = "sha256:7abfb7ea92149b29d046bd34573d247ba6e68cc28100c801eba4af17964fc40e"},
+]
+
+[package.source]
+type = "legacy"
+url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple"
+reference = "artifactory"
+
+[[package]]
 name = "click"
 version = "8.1.7"
 description = "Composable command line interface toolkit"
@@ -1520,6 +1536,25 @@ url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple"
 reference = "artifactory"
 
 [[package]]
+name = "reorder-python-imports"
+version = "3.12.0"
+description = "Tool for reordering python imports"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "reorder_python_imports-3.12.0-py2.py3-none-any.whl", hash = "sha256:930c23a42192b365e20e191a4d304d93e645bd44c242d8bc64accc4a3b2b0f3d"},
+    {file = "reorder_python_imports-3.12.0.tar.gz", hash = "sha256:f93106a662b0c034ca81c91fd1c2f21a1e94ece47c9f192672e2a13c8ec1856c"},
+]
+
+[package.dependencies]
+classify-imports = ">=4.1"
+
+[package.source]
+type = "legacy"
+url = "https://artefacts.tax.service.gov.uk/artifactory/api/pypi/pips/simple"
+reference = "artifactory"
+
+[[package]]
 name = "requests"
 version = "2.31.0"
 description = "Python HTTP for Humans."
@@ -1987,4 +2022,4 @@ reference = "artifactory"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "16c0f0da04e67ce8a34652a4e7e87bd14b04d93f7afd842d0f47ef3837d2150c"
+content-hash = "80acb834849ccd2625566bd02c57ef6216fe2facfbe51ca16709aee71ea1fa98"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ pre-commit = "^2.21.0"
 pytest = "^7.2.0"
 pytest-cov = "^4.0.0"
 version-incrementor = "^1.5.0"
+reorder-python-imports = "^3.12.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/handler.py
+++ b/src/handler.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 import boto3

--- a/src/handler.py
+++ b/src/handler.py
@@ -143,10 +143,9 @@ def enrich_codepipeline_event(event: dict, context: LambdaContext) -> str:
         "enriched_title"
     ] = f"CodePipeline failed: {pipeline}. Committer: @{slack_handle} Sha: {commit_sha[:8]} - {commit_message_summary}"
     event["message-header"] = f"CodePipeline failed: {pipeline}"
-    event["message-content"][
-        "text"
-    ] = f"Committer: @{slack_handle} Sha: {commit_sha[:8]} - {commit_message_summary}"
-
+    event["message-content"] = {
+        "text": f"Committer: @{slack_handle} Sha: {commit_sha[:8]} - {commit_message_summary}"
+    }
     logger.debug(f'Final enriched event: "{event}"')
 
     return event

--- a/src/handler.py
+++ b/src/handler.py
@@ -145,7 +145,7 @@ def enrich_codepipeline_event(event: dict, context: LambdaContext) -> str:
     event["message-content"] = {
         "mrkdwn_in": ["text"],
         "color": "red",
-        "text": f"Build failed after a commit by @{slack_handle} Commit summary: {commit_message_summary}",
+        "text": f"Build failed after a commit by <@{slack_handle}> Commit summary: {commit_message_summary}",
     }
     logger.debug(f'Final enriched event: "{event}"')
 

--- a/src/handler.py
+++ b/src/handler.py
@@ -143,11 +143,9 @@ def enrich_codepipeline_event(event: dict, context: LambdaContext) -> str:
         "enriched_title"
     ] = f"CodePipeline failed: {pipeline}. Committer: @{slack_handle} Sha: {commit_sha[:8]} - {commit_message_summary}"
     event["message-header"] = f"CodePipeline failed: {pipeline}"
-    event["message-content"] = json.dumps(
-        {
-            "text": f"Committer: @{slack_handle} Sha: {commit_sha[:8]} - {commit_message_summary}"
-        }
-    )
+    event["message-content"][
+        "text"
+    ] = f"Committer: @{slack_handle} Sha: {commit_sha[:8]} - {commit_message_summary}"
 
     logger.debug(f'Final enriched event: "{event}"')
 

--- a/src/handler.py
+++ b/src/handler.py
@@ -136,6 +136,7 @@ def enrich_codepipeline_event(event: dict, context: LambdaContext) -> str:
     event["detail"]["slack_handle"] = slack_handle
     commit_sha = commit_data.get("revisionId")
     commit_message_summary = commit_data.get("revisionSummary").partition("\n")[0]
+    commit_url = commit_data.get("revisionUrl")
     event["detail"]["commit_message_summary"] = commit_message_summary
     event["detail"]["commit_url"] = commit_data.get("revisionUrl")
     event["detail"][
@@ -145,7 +146,7 @@ def enrich_codepipeline_event(event: dict, context: LambdaContext) -> str:
     event["message-content"] = {
         "mrkdown_in": ["text"],
         "color": "red",
-        "text": f"Committer: @{slack_handle} Sha: {commit_sha[:8]} - {commit_message_summary}",
+        "text": f"Build failed after a commit by @{slack_handle} with commit {commit_url}",
     }
     logger.debug(f'Final enriched event: "{event}"')
 

--- a/src/handler.py
+++ b/src/handler.py
@@ -160,11 +160,12 @@ def enrich_codepipeline_event(event: dict, context: LambdaContext) -> str:
     commit_url = f"https://github.com/{github_repo}/commit/{commit_sha}"
     revision_summary = json.loads(commit_data["revisionSummary"])
     commit_message_summary = revision_summary["CommitMessage"].partition("\n")[0]
+    pipeline_url = f"https://eu-west-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/{pipeline}/view"
 
     event["message-content"] = {
         "mrkdwn_in": ["text"],
         "color": "danger",
-        "text": f"Build failed after a commit by <@{slack_handle}> - <{commit_url}|{commit_message_summary}>",
+        "text": f"Build of <{pipeline_url}|{pipeline}> failed after a commit by <@{slack_handle}> - <{commit_url}|{commit_message_summary}>",
     }
     logger.debug(f'Final enriched event: "{event}"')
 

--- a/src/handler.py
+++ b/src/handler.py
@@ -144,7 +144,7 @@ def enrich_codepipeline_event(event: dict, context: LambdaContext) -> str:
     ] = f"CodePipeline failed: {pipeline}. Committer: @{slack_handle} Sha: {commit_sha[:8]} - {commit_message_summary}"
     event["message-header"] = f"CodePipeline failed: {pipeline}"
     event["message-content"] = {
-        "mrkdown_in": ["text"],
+        "mrkdwn_in": ["text"],
         "color": "red",
         "text": f"Build failed after a commit by @{slack_handle} with commit {commit_url}",
     }

--- a/src/handler.py
+++ b/src/handler.py
@@ -6,12 +6,11 @@ from aws_lambda_context import LambdaContext
 from aws_lambda_powertools import Logger
 from botocore.config import Config
 from botocore.exceptions import ClientError
+from exceptions import EmptyEventDetailException
+from exceptions import NoExecutionIdFoundException
 from github import Auth
 from github import Github
-
-from .exceptions import EmptyEventDetailException
-from .exceptions import NoExecutionIdFoundException
-from .helper import Helper
+from helper import Helper
 
 config = Config(retries={"max_attempts": 60, "mode": "standard"})
 ssm_client = boto3.client("ssm", config=config, region_name="eu-west-2")

--- a/src/handler.py
+++ b/src/handler.py
@@ -146,7 +146,7 @@ def enrich_codepipeline_event(event: dict, context: LambdaContext) -> str:
     event["message-content"] = {
         "mrkdwn_in": ["text"],
         "color": "red",
-        "text": f"Build failed after a commit by @{slack_handle} with commit {commit_url}",
+        "text": f"Build failed after a commit by @{slack_handle}. Commit summary: {commit_message_summary}",
     }
     logger.debug(f'Final enriched event: "{event}"')
 

--- a/src/handler.py
+++ b/src/handler.py
@@ -138,16 +138,11 @@ def enrich_codepipeline_event(event: dict, context: LambdaContext) -> str:
     commit_sha = commit_data.get("revisionId")
     revision_summary = json.loads(commit_data.get("revisionSummary"))
     commit_message_summary = revision_summary["CommitMessage"].partition("\n")[0]
-    event["detail"]["commit_message_summary"] = commit_message_summary
-    event["detail"]["commit_url"] = commit_data.get("revisionUrl")
-    event["detail"][
-        "enriched_title"
-    ] = f"CodePipeline failed: {pipeline}. Committer: @{slack_handle} Sha: {commit_sha[:8]} - {commit_message_summary}"
     event["message-header"] = f"CodePipeline failed: {pipeline}"
     event["message-content"] = {
         "mrkdwn_in": ["text"],
         "color": "red",
-        "text": f"Build failed after a commit by <@{slack_handle}> Commit summary: {commit_message_summary}",
+        "text": f"Build failed after a commit by <@{slack_handle}> Commit sha: {commit_sha} Commit summary: {commit_message_summary}",
     }
     logger.debug(f'Final enriched event: "{event}"')
 

--- a/src/handler.py
+++ b/src/handler.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import boto3
@@ -135,7 +136,8 @@ def enrich_codepipeline_event(event: dict, context: LambdaContext) -> str:
     slack_handle = helper.get_slack_handle(author_email)
     event["detail"]["slack_handle"] = slack_handle
     commit_sha = commit_data.get("revisionId")
-    commit_message_summary = commit_data.get("revisionSummary").partition("\n")[0]
+    revision_summary = json.loads(commit_data.get("revisionSummary"))
+    commit_message_summary = revision_summary["CommitMessage"].partition("\n")[0]
     event["detail"]["commit_message_summary"] = commit_message_summary
     event["detail"]["commit_url"] = commit_data.get("revisionUrl")
     event["detail"][

--- a/src/handler.py
+++ b/src/handler.py
@@ -135,14 +135,14 @@ def enrich_codepipeline_event(event: dict, context: LambdaContext) -> str:
     # translate git email -> slack id (simple lookup)
     slack_handle = helper.get_slack_handle(author_email)
     event["detail"]["slack_handle"] = slack_handle
-    commit_sha = commit_data.get("revisionId")
+    commit_url = commit_data.get("revisionUrl")
     revision_summary = json.loads(commit_data.get("revisionSummary"))
     commit_message_summary = revision_summary["CommitMessage"].partition("\n")[0]
     event["message-header"] = f"CodePipeline failed: {pipeline}"
     event["message-content"] = {
         "mrkdwn_in": ["text"],
         "color": "red",
-        "text": f"Build failed after a commit by <@{slack_handle}> Commit sha: {commit_sha} Commit summary: {commit_message_summary}",
+        "text": f"Build failed after a commit by <@{slack_handle}> - <{commit_url}|{commit_message_summary}>",
     }
     logger.debug(f'Final enriched event: "{event}"')
 

--- a/src/handler.py
+++ b/src/handler.py
@@ -163,7 +163,7 @@ def enrich_codepipeline_event(event: dict, context: LambdaContext) -> str:
 
     event["message-content"] = {
         "mrkdwn_in": ["text"],
-        "color": "red",
+        "color": "danger",
         "text": f"Build failed after a commit by <@{slack_handle}> - <{commit_url}|{commit_message_summary}>",
     }
     logger.debug(f'Final enriched event: "{event}"')

--- a/src/handler.py
+++ b/src/handler.py
@@ -136,7 +136,6 @@ def enrich_codepipeline_event(event: dict, context: LambdaContext) -> str:
     event["detail"]["slack_handle"] = slack_handle
     commit_sha = commit_data.get("revisionId")
     commit_message_summary = commit_data.get("revisionSummary").partition("\n")[0]
-    commit_url = commit_data.get("revisionUrl")
     event["detail"]["commit_message_summary"] = commit_message_summary
     event["detail"]["commit_url"] = commit_data.get("revisionUrl")
     event["detail"][
@@ -146,7 +145,7 @@ def enrich_codepipeline_event(event: dict, context: LambdaContext) -> str:
     event["message-content"] = {
         "mrkdwn_in": ["text"],
         "color": "red",
-        "text": f"Build failed after a commit by @{slack_handle}. Commit summary: {commit_message_summary}",
+        "text": f"Build failed after a commit by @{slack_handle} Commit summary: {commit_message_summary}",
     }
     logger.debug(f'Final enriched event: "{event}"')
 

--- a/src/handler.py
+++ b/src/handler.py
@@ -143,7 +143,9 @@ def enrich_codepipeline_event(event: dict, context: LambdaContext) -> str:
     ] = f"CodePipeline failed: {pipeline}. Committer: @{slack_handle} Sha: {commit_sha[:8]} - {commit_message_summary}"
     event["message-header"] = f"CodePipeline failed: {pipeline}"
     event["message-content"] = {
-        "text": f"Committer: @{slack_handle} Sha: {commit_sha[:8]} - {commit_message_summary}"
+        "mrkdown_in": ["text"],
+        "color": "red",
+        "text": f"Committer: @{slack_handle} Sha: {commit_sha[:8]} - {commit_message_summary}",
     }
     logger.debug(f'Final enriched event: "{event}"')
 

--- a/src/handler.py
+++ b/src/handler.py
@@ -142,8 +142,8 @@ def enrich_codepipeline_event(event: dict, context: LambdaContext) -> str:
     event["detail"][
         "enriched_title"
     ] = f"CodePipeline failed: {pipeline}. Committer: @{slack_handle} Sha: {commit_sha[:8]} - {commit_message_summary}"
-    event["detail"]["message-header"] = f"CodePipeline failed: {pipeline}"
-    event["detail"]["message-content"] = json.dumps(
+    event["message-header"] = f"CodePipeline failed: {pipeline}"
+    event["message-content"] = json.dumps(
         {
             "text": f"Committer: @{slack_handle} Sha: {commit_sha[:8]} - {commit_message_summary}"
         }

--- a/src/helper.py
+++ b/src/helper.py
@@ -19,7 +19,7 @@ class Helper:
     ):
         self.logger = logger
 
-    def get_slack_handle(self, github_email):
+    def get_slack_handle(self, github_email: str) -> str:
         # Default to telemetry-engineers if it's an unknown user
         slack_handle = "telemetry-engineers"
         if github_email in self.github_to_slack:

--- a/src/helper.py
+++ b/src/helper.py
@@ -6,12 +6,11 @@ class Helper:
         "1422984+webit4me@users.noreply.github.com": "ali.bahman",
         "abn@webit4.me": "ali.bahman",
         "gavD@users.noreply.github.com": "gavin.davies1",
-        "22219356+matthew-hollick@users.noreply.github.com": "matthew.hollick",
         "ma3574@users.noreply.github.com": "muhammed.ahmed",
         "66684341+rizinaa99@users.noreply.github.com": "rizina.khatun",
         "Crumplepang@users.noreply.github.com": "rob.white",
         "18111914+sjpalf@users.noreply.github.com": "stephen.palfreyman",
-        "67912934+TimothyFothergill@users.noreply.github.com": "timothy.fothergill",
+        "60072280+jonnydh@users.noreply.github.com": "jonathan.heywood",
     }
 
     def __init__(

--- a/src/scratch.py
+++ b/src/scratch.py
@@ -1,0 +1,8 @@
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
+
+url = "https://www.example.com/redirect?connectionArn=blah&referenceType=COMMIT&FullRepositoryId=hmrc/telemetry-terraform&Commit=a9e1670"
+parsed_url = urlparse(url)
+captured_value = parse_qs(parsed_url.query)["FullRepositoryId"][0]
+
+print(captured_value)

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -49,7 +49,7 @@ def ssm(aws_credentials):
 
 @pytest.fixture(scope="function")
 def codepipeline_client_stub():
-    from handler import pipeline_client
+    from src.handler import pipeline_client
 
     with Stubber(pipeline_client) as stubber:
         stubber.activate()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -49,7 +49,7 @@ def ssm(aws_credentials):
 
 @pytest.fixture(scope="function")
 def codepipeline_client_stub():
-    from src.handler import pipeline_client
+    from handler import pipeline_client
 
     with Stubber(pipeline_client) as stubber:
         stubber.activate()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -70,7 +70,7 @@ def get_pipeline_execution_success_fixture():
                 {
                     "name": "source_output",
                     "revisionId": "bc051f8d7fbf183dbb840462cb5c17d887964842",
-                    "revisionSummary": "TEL-3481 create pagerduty-config-deployer\n\nBunch of text",
+                    "revisionSummary": '{"ProviderType":"GitHub","CommitMessage":"TEL-3481 create pagerduty-config-deployer\\n\\nBunch of text"}',
                     "revisionUrl": "https://github.com/hmrc/telemetry-terraform/commit/bc051f8d7fbf183dbb840462cb5c17d887964842",
                 }
             ],

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -71,7 +71,7 @@ def get_pipeline_execution_success_fixture():
                     "name": "source_output",
                     "revisionId": "bc051f8d7fbf183dbb840462cb5c17d887964842",
                     "revisionSummary": '{"ProviderType":"GitHub","CommitMessage":"TEL-3481 create pagerduty-config-deployer\\n\\nBunch of text"}',
-                    "revisionUrl": "https://github.com/hmrc/telemetry-terraform/commit/bc051f8d7fbf183dbb840462cb5c17d887964842",
+                    "revisionUrl": "https://codestarurl/redirect?connectionArn=blah&referenceType=COMMIT&FullRepositoryId=hmrc/telemetry-terraform&Commit=a9e1670",
                 }
             ],
         },

--- a/tests/unit/handler_test.py
+++ b/tests/unit/handler_test.py
@@ -185,20 +185,12 @@ def test_handler_golden_path(
     response = enrich_codepipeline_event(cloudwatch_event_pipeline_failed, context)
 
     # Assert
-    assert response is not None
-    assert response.get("detail").get("slack_handle") == "stephen.palfreyman"
-    assert (
-        response.get("detail").get("commit_message_summary")
-        == "TEL-3481 create pagerduty-config-deployer"
-    )
-    assert (
-        response.get("detail").get("enriched_title")
-        == "CodePipeline failed: myPipeline. Committer: @stephen.palfreyman Sha: bc051f8d - TEL-3481 create pagerduty-config-deployer"
-    )
-    assert (
-        response.get("detail").get("commit_url")
-        == "https://github.com/hmrc/telemetry-terraform/commit/bc051f8d7fbf183dbb840462cb5c17d887964842"
-    )
+    assert response.get("message-header") == "CodePipeline failed: myPipeline"
+    assert response.get("message-content") == {
+        "mrkdwn_in": ["text"],
+        "color": "red",
+        "text": "Build failed after a commit by <@stephen.palfreyman> Commit sha: bc051f8d7fbf183dbb840462cb5c17d887964842 Commit summary: TEL-3481 create pagerduty-config-deployer",
+    }
 
 
 def test_lambda_handler_invalid_event_empty_detail_with_context(
@@ -264,17 +256,9 @@ def test_handler_sqs_golden_path(
     )
 
     # Assert
-    assert response is not None
-    assert response.get("detail").get("slack_handle") == "ali.bahman"
-    assert (
-        response.get("detail").get("commit_message_summary")
-        == "TEL-3481 create pagerduty-config-deployer"
-    )
-    assert (
-        response.get("detail").get("enriched_title")
-        == "CodePipeline failed: TEL-2490. Committer: @ali.bahman Sha: bc051f8d - TEL-3481 create pagerduty-config-deployer"
-    )
-    assert (
-        response.get("detail").get("commit_url")
-        == "https://github.com/hmrc/telemetry-terraform/commit/bc051f8d7fbf183dbb840462cb5c17d887964842"
-    )
+    assert response.get("message-header") == "CodePipeline failed: TEL-2490"
+    assert response.get("message-content") == {
+        "mrkdwn_in": ["text"],
+        "color": "red",
+        "text": "Build failed after a commit by <@ali.bahman> Commit sha: bc051f8d7fbf183dbb840462cb5c17d887964842 Commit summary: TEL-3481 create pagerduty-config-deployer",
+    }

--- a/tests/unit/handler_test.py
+++ b/tests/unit/handler_test.py
@@ -9,7 +9,7 @@ from github import Github
 def test_get_ssm_parameter(ssm):
     """Test that retrieving an SSM parameter that does exist returns the parameter"""
     # Arrange & Act
-    from src.handler import get_ssm_parameter
+    from handler import get_ssm_parameter
 
     ssm.put_parameter(Name="foo", Value="bar", Type="SecureString")
     parameter_result = get_ssm_parameter("foo")
@@ -21,7 +21,7 @@ def test_get_ssm_parameter(ssm):
 def test_get_ssm_parameter_raises_error(ssm):
     """Test that retrieving an SSM parameter that does not exist raises an error"""
     # Arrange & Act
-    from src.handler import get_ssm_parameter
+    from handler import get_ssm_parameter
 
     with pytest.raises(ClientError):
         parameter_result = get_ssm_parameter("foo")
@@ -34,7 +34,7 @@ def test_get_pipeline_commit_data_returns_commit_from_source_output(
     codepipeline_client_stub, get_pipeline_execution_success_fixture
 ):
     # Arrange
-    from src.handler import get_pipeline_commit_data
+    from handler import get_pipeline_commit_data
 
     codepipeline_client_stub.add_response(
         "get_pipeline_execution", get_pipeline_execution_success_fixture
@@ -58,7 +58,7 @@ def test_get_pipeline_commit_data_returns_empty_with_no_source_output(
     codepipeline_client_stub, get_pipeline_execution_failure_fixture
 ):
     # Arrange
-    from src.handler import get_pipeline_commit_data
+    from handler import get_pipeline_commit_data
 
     codepipeline_client_stub.add_response(
         "get_pipeline_execution", get_pipeline_execution_failure_fixture
@@ -83,7 +83,7 @@ def test_get_github_author_returns_valid(
     mock_get_repo, codepipeline_client_stub, get_pipeline_execution_failure_fixture
 ):
     # Arrange
-    from src.handler import get_github_author_email
+    from handler import get_github_author_email
 
     author = mock.Mock()
     author.email = "mock@example.com"
@@ -104,7 +104,7 @@ def test_get_github_author_returns_not_found(
     codepipeline_client_stub, get_pipeline_execution_failure_fixture
 ):
     # Arrange
-    from src.handler import get_github_author_email
+    from handler import get_github_author_email
 
     # Act
     author_email = get_github_author_email("mock_token", "")
@@ -117,7 +117,7 @@ def test_get_pipeline_execution_handles_incorrect_execution_id(
     codepipeline_client_stub,
 ):
     # Arrange
-    from src.handler import get_pipeline_commit_data
+    from handler import get_pipeline_commit_data
 
     codepipeline_client_stub.add_client_error(
         "get_pipeline_execution",
@@ -139,7 +139,7 @@ def test_get_pipeline_execution_handles_incorrect_execution_id(
 
 def test_get_pipeline_execution_handles_incorrect_pipeline(codepipeline_client_stub):
     # Arrange
-    from src.handler import get_pipeline_commit_data
+    from handler import get_pipeline_commit_data
 
     codepipeline_client_stub.add_client_error(
         "get_pipeline_execution",
@@ -159,7 +159,7 @@ def test_get_pipeline_execution_handles_incorrect_pipeline(codepipeline_client_s
     )
 
 
-@patch("src.handler.get_github_author_email")
+@patch("handler.get_github_author_email")
 def test_handler_golden_path(
     mock_github_author_email,
     ssm,
@@ -169,7 +169,7 @@ def test_handler_golden_path(
     context,
 ):
     # Arrange
-    from src.handler import enrich_codepipeline_event
+    from handler import enrich_codepipeline_event
 
     mock_github_author_email.return_value = "18111914+sjpalf@users.noreply.github.com"
     ssm.put_parameter(
@@ -206,8 +206,8 @@ def test_lambda_handler_invalid_event_empty_detail_with_context(
 ):
     """Test that an event containing unexpected data with lambda context logs appropriately"""
     # Arrange & Act
-    from src.exceptions import EmptyEventDetailException
-    from src.handler import enrich_codepipeline_event
+    from exceptions import EmptyEventDetailException
+    from handler import enrich_codepipeline_event
 
     with pytest.raises(EmptyEventDetailException):
         response = enrich_codepipeline_event(
@@ -223,8 +223,8 @@ def test_lambda_handler_invalid_event_with_no_execution_id(
 ):
     """Test that an event containing missing and required data with lambda context logs appropriately"""
     # Arrange & Act
-    from src.exceptions import NoExecutionIdFoundException
-    from src.handler import enrich_codepipeline_event
+    from exceptions import NoExecutionIdFoundException
+    from handler import enrich_codepipeline_event
 
     with pytest.raises(NoExecutionIdFoundException):
         response = enrich_codepipeline_event(
@@ -235,7 +235,7 @@ def test_lambda_handler_invalid_event_with_no_execution_id(
         assert response is None
 
 
-@patch("src.handler.get_github_author_email")
+@patch("handler.get_github_author_email")
 def test_handler_sqs_golden_path(
     mock_github_author_email,
     ssm,
@@ -245,7 +245,7 @@ def test_handler_sqs_golden_path(
     context,
 ):
     # Arrange
-    from src.handler import enrich_sqs_event
+    from handler import enrich_sqs_event
 
     mock_github_author_email.return_value = "abn@webit4.me"
     # mock_get_github_commit_message_summary.return_value = "[TEL-1234] Here is a commit"

--- a/tests/unit/handler_test.py
+++ b/tests/unit/handler_test.py
@@ -189,7 +189,7 @@ def test_handler_golden_path(
     assert response.get("message-content") == {
         "mrkdwn_in": ["text"],
         "color": "red",
-        "text": "Build failed after a commit by <@stephen.palfreyman> Commit sha: bc051f8d7fbf183dbb840462cb5c17d887964842 Commit summary: TEL-3481 create pagerduty-config-deployer",
+        "text": "Build failed after a commit by <@stephen.palfreyman> - <https://github.com/hmrc/telemetry-terraform/commit/bc051f8d7fbf183dbb840462cb5c17d887964842|TEL-3481 create pagerduty-config-deployer>",
     }
 
 
@@ -260,5 +260,5 @@ def test_handler_sqs_golden_path(
     assert response.get("message-content") == {
         "mrkdwn_in": ["text"],
         "color": "red",
-        "text": "Build failed after a commit by <@ali.bahman> Commit sha: bc051f8d7fbf183dbb840462cb5c17d887964842 Commit summary: TEL-3481 create pagerduty-config-deployer",
+        "text": "Build failed after a commit by <@ali.bahman> - <https://github.com/hmrc/telemetry-terraform/commit/bc051f8d7fbf183dbb840462cb5c17d887964842|TEL-3481 create pagerduty-config-deployer>",
     }

--- a/tests/unit/handler_test.py
+++ b/tests/unit/handler_test.py
@@ -49,7 +49,7 @@ def test_get_pipeline_commit_data_returns_commit_from_source_output(
     assert git_data == {
         "name": "source_output",
         "revisionId": "bc051f8d7fbf183dbb840462cb5c17d887964842",
-        "revisionSummary": "TEL-3481 create pagerduty-config-deployer\n\nBunch of text",
+        "revisionSummary": '{"ProviderType":"GitHub","CommitMessage":"TEL-3481 create pagerduty-config-deployer\\n\\nBunch of text"}',
         "revisionUrl": "https://github.com/hmrc/telemetry-terraform/commit/bc051f8d7fbf183dbb840462cb5c17d887964842",
     }
 

--- a/tests/unit/handler_test.py
+++ b/tests/unit/handler_test.py
@@ -9,7 +9,7 @@ from github import Github
 def test_get_ssm_parameter(ssm):
     """Test that retrieving an SSM parameter that does exist returns the parameter"""
     # Arrange & Act
-    from handler import get_ssm_parameter
+    from src.handler import get_ssm_parameter
 
     ssm.put_parameter(Name="foo", Value="bar", Type="SecureString")
     parameter_result = get_ssm_parameter("foo")
@@ -21,7 +21,7 @@ def test_get_ssm_parameter(ssm):
 def test_get_ssm_parameter_raises_error(ssm):
     """Test that retrieving an SSM parameter that does not exist raises an error"""
     # Arrange & Act
-    from handler import get_ssm_parameter
+    from src.handler import get_ssm_parameter
 
     with pytest.raises(ClientError):
         parameter_result = get_ssm_parameter("foo")
@@ -34,7 +34,7 @@ def test_get_pipeline_commit_data_returns_commit_from_source_output(
     codepipeline_client_stub, get_pipeline_execution_success_fixture
 ):
     # Arrange
-    from handler import get_pipeline_commit_data
+    from src.handler import get_pipeline_commit_data
 
     codepipeline_client_stub.add_response(
         "get_pipeline_execution", get_pipeline_execution_success_fixture
@@ -58,7 +58,7 @@ def test_get_pipeline_commit_data_returns_empty_with_no_source_output(
     codepipeline_client_stub, get_pipeline_execution_failure_fixture
 ):
     # Arrange
-    from handler import get_pipeline_commit_data
+    from src.handler import get_pipeline_commit_data
 
     codepipeline_client_stub.add_response(
         "get_pipeline_execution", get_pipeline_execution_failure_fixture
@@ -83,7 +83,7 @@ def test_get_github_author_returns_valid(
     mock_get_repo, codepipeline_client_stub, get_pipeline_execution_failure_fixture
 ):
     # Arrange
-    from handler import get_github_author_email
+    from src.handler import get_github_author_email
 
     author = mock.Mock()
     author.email = "mock@example.com"
@@ -104,7 +104,7 @@ def test_get_github_author_returns_not_found(
     codepipeline_client_stub, get_pipeline_execution_failure_fixture
 ):
     # Arrange
-    from handler import get_github_author_email
+    from src.handler import get_github_author_email
 
     # Act
     author_email = get_github_author_email("mock_token", "")
@@ -117,7 +117,7 @@ def test_get_pipeline_execution_handles_incorrect_execution_id(
     codepipeline_client_stub,
 ):
     # Arrange
-    from handler import get_pipeline_commit_data
+    from src.handler import get_pipeline_commit_data
 
     codepipeline_client_stub.add_client_error(
         "get_pipeline_execution",
@@ -139,7 +139,7 @@ def test_get_pipeline_execution_handles_incorrect_execution_id(
 
 def test_get_pipeline_execution_handles_incorrect_pipeline(codepipeline_client_stub):
     # Arrange
-    from handler import get_pipeline_commit_data
+    from src.handler import get_pipeline_commit_data
 
     codepipeline_client_stub.add_client_error(
         "get_pipeline_execution",
@@ -159,7 +159,7 @@ def test_get_pipeline_execution_handles_incorrect_pipeline(codepipeline_client_s
     )
 
 
-@patch("handler.get_github_author_email")
+@patch("src.handler.get_github_author_email")
 def test_handler_golden_path(
     mock_github_author_email,
     ssm,
@@ -169,7 +169,7 @@ def test_handler_golden_path(
     context,
 ):
     # Arrange
-    from handler import enrich_codepipeline_event
+    from src.handler import enrich_codepipeline_event
 
     mock_github_author_email.return_value = "18111914+sjpalf@users.noreply.github.com"
     ssm.put_parameter(
@@ -206,8 +206,8 @@ def test_lambda_handler_invalid_event_empty_detail_with_context(
 ):
     """Test that an event containing unexpected data with lambda context logs appropriately"""
     # Arrange & Act
-    from exceptions import EmptyEventDetailException
-    from handler import enrich_codepipeline_event
+    from src.exceptions import EmptyEventDetailException
+    from src.handler import enrich_codepipeline_event
 
     with pytest.raises(EmptyEventDetailException):
         response = enrich_codepipeline_event(
@@ -223,8 +223,8 @@ def test_lambda_handler_invalid_event_with_no_execution_id(
 ):
     """Test that an event containing missing and required data with lambda context logs appropriately"""
     # Arrange & Act
-    from exceptions import NoExecutionIdFoundException
-    from handler import enrich_codepipeline_event
+    from src.exceptions import NoExecutionIdFoundException
+    from src.handler import enrich_codepipeline_event
 
     with pytest.raises(NoExecutionIdFoundException):
         response = enrich_codepipeline_event(
@@ -235,7 +235,7 @@ def test_lambda_handler_invalid_event_with_no_execution_id(
         assert response is None
 
 
-@patch("handler.get_github_author_email")
+@patch("src.handler.get_github_author_email")
 def test_handler_sqs_golden_path(
     mock_github_author_email,
     ssm,
@@ -245,7 +245,7 @@ def test_handler_sqs_golden_path(
     context,
 ):
     # Arrange
-    from handler import enrich_sqs_event
+    from src.handler import enrich_sqs_event
 
     mock_github_author_email.return_value = "abn@webit4.me"
     # mock_get_github_commit_message_summary.return_value = "[TEL-1234] Here is a commit"

--- a/tests/unit/handler_test.py
+++ b/tests/unit/handler_test.py
@@ -183,7 +183,7 @@ def test_handler_golden_path(
     assert response.get("message-header") == "CodePipeline failed: myPipeline"
     assert response.get("message-content") == {
         "mrkdwn_in": ["text"],
-        "color": "red",
+        "color": "danger",
         "text": "Build failed after a commit by <@stephen.palfreyman> - <https://github.com/hmrc/telemetry-terraform/commit/bc051f8d7fbf183dbb840462cb5c17d887964842|TEL-3481 create pagerduty-config-deployer>",
     }
 
@@ -254,7 +254,7 @@ def test_handler_sqs_golden_path(
     assert response.get("message-header") == "CodePipeline failed: TEL-2490"
     assert response.get("message-content") == {
         "mrkdwn_in": ["text"],
-        "color": "red",
+        "color": "danger",
         "text": "Build failed after a commit by <@ali.bahman> - <https://github.com/hmrc/telemetry-terraform/commit/bc051f8d7fbf183dbb840462cb5c17d887964842|TEL-3481 create pagerduty-config-deployer>",
     }
 

--- a/tests/unit/handler_test.py
+++ b/tests/unit/handler_test.py
@@ -50,7 +50,7 @@ def test_get_pipeline_commit_data_returns_commit_from_source_output(
         "name": "source_output",
         "revisionId": "bc051f8d7fbf183dbb840462cb5c17d887964842",
         "revisionSummary": '{"ProviderType":"GitHub","CommitMessage":"TEL-3481 create pagerduty-config-deployer\\n\\nBunch of text"}',
-        "revisionUrl": "https://github.com/hmrc/telemetry-terraform/commit/bc051f8d7fbf183dbb840462cb5c17d887964842",
+        "revisionUrl": "https://codestarurl/redirect?connectionArn=blah&referenceType=COMMIT&FullRepositoryId=hmrc/telemetry-terraform&Commit=a9e1670",
     }
 
 
@@ -65,17 +65,12 @@ def test_get_pipeline_commit_data_returns_empty_with_no_source_output(
     )
 
     # Act
-    git_data = get_pipeline_commit_data(
+    commit_data = get_pipeline_commit_data(
         "telemetry-terraform-pipeline", "0d18ecc5-2611-436b-9d2f-ba7e9bfc721d"
     )
 
     # Assert
-    assert git_data == {
-        "name": "",
-        "revisionId": "",
-        "revisionSummary": "",
-        "revisionUrl": "",
-    }
+    assert commit_data == {}
 
 
 @patch.object(Github, "get_repo")
@@ -94,7 +89,7 @@ def test_get_github_author_returns_valid(
     mock_get_repo.return_value.get_commit.return_value = mock_commit
 
     # Act
-    author_email = get_github_author_email("mock_token", "mock_sha")
+    author_email = get_github_author_email("mock_token", "mock_repo", "mock_sha")
 
     # Assert
     assert author_email == "mock@example.com"
@@ -107,7 +102,7 @@ def test_get_github_author_returns_not_found(
     from handler import get_github_author_email
 
     # Act
-    author_email = get_github_author_email("mock_token", "")
+    author_email = get_github_author_email("mock_token", "mock_repo", "")
 
     # Assert
     assert author_email == "<not found - empty sha>"
@@ -262,3 +257,29 @@ def test_handler_sqs_golden_path(
         "color": "red",
         "text": "Build failed after a commit by <@ali.bahman> - <https://github.com/hmrc/telemetry-terraform/commit/bc051f8d7fbf183dbb840462cb5c17d887964842|TEL-3481 create pagerduty-config-deployer>",
     }
+
+
+def test_handler_no_pipeline_execution_source_output(
+    ssm,
+    codepipeline_client_stub,
+    get_pipeline_execution_failure_fixture,
+    cloudwatch_event_pipeline_failed,
+    context,
+):
+    # Arrange
+    from handler import enrich_codepipeline_event
+
+    ssm.put_parameter(
+        Name="/secrets/github/telemetry_github_token",
+        Value="token123",
+        Type="SecureString",
+    )
+    codepipeline_client_stub.add_response(
+        "get_pipeline_execution", get_pipeline_execution_failure_fixture
+    )
+
+    # Act
+    response = enrich_codepipeline_event(cloudwatch_event_pipeline_failed, context)
+
+    # Assert
+    assert response.get("message-header") == "CodePipeline failed: myPipeline"

--- a/tests/unit/handler_test.py
+++ b/tests/unit/handler_test.py
@@ -184,7 +184,7 @@ def test_handler_golden_path(
     assert response.get("message-content") == {
         "mrkdwn_in": ["text"],
         "color": "danger",
-        "text": "Build failed after a commit by <@stephen.palfreyman> - <https://github.com/hmrc/telemetry-terraform/commit/bc051f8d7fbf183dbb840462cb5c17d887964842|TEL-3481 create pagerduty-config-deployer>",
+        "text": "Build of <https://eu-west-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/myPipeline/view|myPipeline> failed after a commit by <@stephen.palfreyman> - <https://github.com/hmrc/telemetry-terraform/commit/bc051f8d7fbf183dbb840462cb5c17d887964842|TEL-3481 create pagerduty-config-deployer>",
     }
 
 
@@ -255,7 +255,7 @@ def test_handler_sqs_golden_path(
     assert response.get("message-content") == {
         "mrkdwn_in": ["text"],
         "color": "danger",
-        "text": "Build failed after a commit by <@ali.bahman> - <https://github.com/hmrc/telemetry-terraform/commit/bc051f8d7fbf183dbb840462cb5c17d887964842|TEL-3481 create pagerduty-config-deployer>",
+        "text": "Build of <https://eu-west-2.console.aws.amazon.com/codesuite/codepipeline/pipelines/TEL-2490/view|TEL-2490> failed after a commit by <@ali.bahman> - <https://github.com/hmrc/telemetry-terraform/commit/bc051f8d7fbf183dbb840462cb5c17d887964842|TEL-3481 create pagerduty-config-deployer>",
     }
 
 

--- a/tests/unit/helper_test.py
+++ b/tests/unit/helper_test.py
@@ -2,8 +2,7 @@ import os
 
 import pytest
 from aws_lambda_powertools import Logger
-
-from src.helper import Helper
+from helper import Helper
 
 
 @pytest.fixture

--- a/tests/unit/helper_test.py
+++ b/tests/unit/helper_test.py
@@ -2,7 +2,8 @@ import os
 
 import pytest
 from aws_lambda_powertools import Logger
-from helper import Helper
+
+from src.helper import Helper
 
 
 @pytest.fixture


### PR DESCRIPTION
What did we do?
--

1. Updated the output so that it adds `message-header` and `message-content` to the event so that it can be sent to slack via the slack-notifications lambda.
2. Get the github repo from the pipeline execution details, rather than hardcoding it (so that we can use this lambda for more than just telemetry-terraform repo)
3. Add jonny heywood and remove mat hollick & tim fothergill
4. Update test data to more accurately reflect the output for getting pipeline execution details
5. Fix code so that it actually gets the first line of the commit
6. Add a link to the actual commit from the slack message
7. Add a link to the codepipeline aws console
8. Updated the colour of the slack message to red

References
--

https://jira.tools.tax.service.gov.uk/browse/TEL-3506
https://hmrcdigital.slack.com/archives/CQ5G3ADHQ/p1702833157652529

Evidence of work
--

1. Tested in base and received this message in slack:
<img width="677" alt="image" src="https://github.com/hmrc/aws-lambda-telemetry-eventbridge-enrichment/assets/18111914/35961f86-1659-40e9-a20c-0d897353e919">

Collaboration
--

Co-authored-by: Ali Bahman <1422984+webit4me@users.noreply.github.com>
