### PR TITLE
BAU add lee.myring back into the GH Slack mapping

### DIFF
--- a/src/helper.py
+++ b/src/helper.py
@@ -5,6 +5,7 @@ class Helper:
     github_to_slack = {
         "150913287+wrightda101@users.noreply.github.com": "damon.wright",
         "52657898+dave-miles-hmrc@users.noreply.github.com": "david.miles",
+        "3706672+deploymentking@users.noreply.github.com": "lee.myring",
         "9415522+duddingl@users.noreply.github.com": "lyndon.dudding",
         "1253988+nisartahir@users.noreply.github.com": "nisar.tahir",
     }


### PR DESCRIPTION
What did we do?
--

1. added my GitHub email to the Slack mapping

References
--

https://hmrcdigital.slack.com/archives/G5NJ492HH/p1779199060826009

Evidence of work
--

1. 

Next Steps
--

1. merge

Risks
--

1. none

Collaboration
--

Co-authored-by: @dave-miles-hmrc 
